### PR TITLE
Add support for the feature tests

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,32 +1,34 @@
 const parsers = {
   default: (output) => {
     const pattern =
-      /(.+?)(?=Finished)(.+sync\))\n([0-9]+ doctest[s]?, )?([0-9]+ test[s]?, )([0-9]+ failure[s]?)(.+)(Randomized with seed [0-9]+)(.+)(Percentage \| Module.+)( [0-9]+\.[0-9]+%)( \| Total)/gs;
+      /(.+?)(?=Finished)(.+sync\))\n([0-9]+ features[s]?, )?([0-9]+ doctest[s]?, )?([0-9]+ test[s]?, )([0-9]+ failure[s]?)(.+)(Randomized with seed [0-9]+)(.+)(Percentage \| Module.+)( [0-9]+\.[0-9]+%)( \| Total)/gs;
     const groups = pattern.exec(output);
 
     return {
       summary: groups[2],
-      docTests: parseInt(groups[3]),
-      totalTests: parseInt(groups[4]),
-      totalFailures: parseInt(groups[5]),
-      totalCoverage: parseFloat(groups[10]),
-      randomizedSeed: groups[7],
-      coverageTable: groups[9] + groups[10] + groups[11],
+      featureTests: parseInt(groups[3]),
+      docTests: parseInt(groups[4]),
+      totalTests: parseInt(groups[5]),
+      totalFailures: parseInt(groups[6]),
+      totalCoverage: parseFloat(groups[11]),
+      randomizedSeed: groups[8],
+      coverageTable: groups[10] + groups[11] + groups[12],
     };
   },
   excoveralls: (output) => {
     const pattern =
-      /(.+?)(?=Finished)(.+sync\))\n([0-9]+ doctest[s]?, )?([0-9]+ test[s]?, )([0-9]+ failure[s]?)(.+)(Randomized with seed [0-9]+)(.+)(\[TOTAL\][ ]+)([0-9]+\.[0-9]+%)(.+)/gs;
+      /(.+?)(?=Finished)(.+sync\))\n([0-9]+ features[s]?, )?([0-9]+ doctest[s]?, )?([0-9]+ test[s]?, )([0-9]+ failure[s]?)(.+)(Randomized with seed [0-9]+)(.+)(\[TOTAL\][ ]+)([0-9]+\.[0-9]+%)(.+)/gs;
     const groups = pattern.exec(output);
 
     return {
       summary: groups[2],
-      docTests: parseInt(groups[3]),
-      totalTests: parseInt(groups[4]),
-      totalFailures: parseInt(groups[5]),
-      totalCoverage: parseFloat(groups[10]),
-      randomizedSeed: groups[7],
-      coverageTable: groups[8] + groups[9] + groups[10] + groups[11],
+      featureTests: parseInt(groups[3]),
+      docTests: parseInt(groups[4]),
+      totalTests: parseInt(groups[5]),
+      totalFailures: parseInt(groups[6]),
+      totalCoverage: parseFloat(groups[11]),
+      randomizedSeed: groups[8],
+      coverageTable: groups[9] + groups[10] + groups[11] + groups[12],
     };
   },
 };
@@ -37,6 +39,7 @@ const buildComment = ({
   summary,
   randomizedSeed,
   testsSuccess,
+  featureTests,
   docTests,
   totalTests,
   totalFailures,
@@ -50,7 +53,7 @@ const buildComment = ({
 ${summary}
 ${randomizedSeed}
 
-${statusEmoji(testsSuccess)} **${docTests || 0} doctests, ${totalTests} tests, ${totalFailures} failures**
+${statusEmoji(testsSuccess)} **${featureTests || 0} features, ${docTests || 0} doctests, ${totalTests} tests, ${totalFailures} failures**
 ${statusEmoji(coverageSuccess)} **${totalCoverage}% coverage (${coverageThreshold}% is the minimum)**
 
 <details>


### PR DESCRIPTION
The goal of this PR is to add support for feature tests when running coverage.

When running the elixir-coverage-feedback-action for the Phoenix LiveView application I encountered the following issue:
```
TypeError: Cannot read properties of null (reading '2')
    at default (/home/runner/work/_actions/josecfreittas/elixir-coverage-feedback-action/v0.4/script.js:8:22)
    at module.exports (/home/runner/work/_actions/josecfreittas/elixir-coverage-feedback-action/v0.4/script.js:92:16)
```

Also, I noticed that the test output is in the following format:
```
Finished in 161.0 seconds (5.4s async, 155.6s sync)
24 features, 241 tests, 0 failures, 2 excluded
```

This PR adds the support to capture and report feature tests. Tested on the fork, tests succeed and updated reports are in the following format:

For the application without feature tests:
![image](https://github.com/josecfreittas/elixir-coverage-feedback-action/assets/57402257/ea7a9f4d-fe1b-4be9-82e5-e4c4f9355a7b)


For the application with feature tests:
![image](https://github.com/josecfreittas/elixir-coverage-feedback-action/assets/57402257/75dc86e3-9e9b-4431-a7f9-980e2044f3b6)

The changes are inspired by the PR with adding support for the doctest and the changes are analogous. 