### PR TITLE
fix: support excluded tags

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -18,7 +18,7 @@ const oldParser = {
 
 // Used for Elixir >= 1.17
 const newParser = {
-  pattern: /(Running ExUnit with seed: [0-9]+, max_cases: [0-9]+\n\n)(.+?)(?=Finished)(Finished.+sync\))\n(.*?)([0-9]+ failure[s]?)(.+?)(Percentage \| Module.+)((?:\n.+)+\n-+\|-+\n\s+([0-9]+\.[0-9]+)%\s+\|\s+Total)/s,
+  pattern: /(Running ExUnit with seed: [0-9]+, max_cases: [0-9]+\n+)(.+?)(?=Finished)(Finished.+sync\))\n(.*?)([0-9]+ failure[s]?)(.+?)(Percentage \| Module.+)((?:\n.+)+\n-+\|-+\n\s+([0-9]+\.[0-9]+)%\s+\|\s+Total)/s,
   mapGroupsToData: (groups) => ({
     summary: groups[3],
     tests: groups[4].slice(0, -2),

--- a/tests/fixtures/success_04
+++ b/tests/fixtures/success_04
@@ -1,0 +1,21 @@
+Getting extensions in current project...
+Running setup for AshPostgres.DataLayer...
+Cover compiling modules ...
+Running ExUnit with seed: 980561, max_cases: 20
+Excluding tags: [:e2e, :skip]
+
+.....
+Finished in 0.1 seconds (0.06s async, 0.09s sync)
+1 feature, 5 tests, 0 failures, 1 excluded
+Wrote JUnit report to: ./test-output/myapp-report_file_test.xml
+
+Generating cover results ...
+
+Percentage | Module
+-----------|--------------------------
+   100.00% | MyApp
+   100.00% | MyAppWeb.PageController
+-----------|--------------------------
+   100.00% | Total
+
+Generated HTML coverage results in "cover" directory


### PR DESCRIPTION
Update regex to support excluded tags

@josecfreittas can you have a look at this? I have based the changes on this PR: https://github.com/josecfreittas/elixir-coverage-feedback-action/pull/36 

The tests pass locally and in CI, it's just the token I'm using that seems to have issues 